### PR TITLE
"Fixes" phantomjs caching issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,10 +1,27 @@
 var prerender = require('prerender');
 
 var server = prerender({
-    workers: process.env.PRERENDER_NUM_WORKERS || 4
+	workers: process.env.PRERENDER_NUM_WORKERS || 4
 });
 
 
+server.use({
+	//There are some issues with the in-memory cache from PhantomJS 2. It keeps pages in memory,
+	//and then simply returns a 304 instead of a 200 whenever possible.
+	//Prerender unfortunatally simply proxies this status code, even though the client doesn't necessarily
+	//have the page in cache.
+	//In order to prevent this we need to clear the memory cache of PhantomJS before each request
+	onPhantomPageCreate: function(phantom, req, res, next) {
+		//The run function is exposed by phridge (bridge between prerender and PhantomJS), and allows
+		//us to run commands in the page context
+		req.prerender.page.run(function(resolve) {
+			this.clearMemoryCache();
+			resolve();
+		})
+		.then(function() { next() })
+		.catch(function() { next() });
+	}
+});
 server.use(prerender.sendPrerenderHeader());
 server.use(prerender.blacklist());
 server.use(prerender.removeScriptTags());


### PR DESCRIPTION
PhantomJS has an internal cache that doesn't work properly. It causes
304s to be returned, even though the client has no idea what the content
is. This commit adds a prerender plugin that simply clears the cache
before each request.

@rogierslag - Can you review and publish a new container? (Or help me out publishing it)