### PR TITLE
Forward headers sent to prerender

### DIFF
--- a/clearPhantomCache.js
+++ b/clearPhantomCache.js
@@ -1,0 +1,21 @@
+module.exports = {
+  // There are some issues with the in-memory cache from PhantomJS 2. It keeps pages in memory,
+  // and then simply returns a 304 instead of a 200 whenever possible.
+  // Prerender unfortunatally simply proxies this status code, even though the client doesn't necessarily
+  // have the page in cache.
+  // In order to prevent this we need to clear the memory cache of PhantomJS before each request
+  onPhantomPageCreate: function (phantom, req, res, next) {
+    //The run function is exposed by phridge (bridge between prerender and PhantomJS), and allows
+    //us to run commands in the page context
+    req.prerender.page.run(function (resolve) {
+      this.clearMemoryCache();
+      resolve();
+    })
+      .then(function () {
+        next()
+      })
+      .catch(function () {
+        next()
+      });
+  }
+};

--- a/forwardHeaders.js
+++ b/forwardHeaders.js
@@ -1,0 +1,36 @@
+// Set all blacklisted headers as lowercase
+var BLACKLISTED = ['user-agent','host'];
+
+module.exports = {
+  // Since prerender does not forward headers, this causes problems for some crawlers looking for
+  // e.g. localized content. This plugin ensures the headers sent to prerender are also set in
+  // the PhantomJS instance. Some headers may be blacklisted and will not be forwarded.
+  onPhantomPageCreate: function (phantom, req, res, next) {
+    // The following function is executed in the Phridge context, which means we do not have a
+    // regular closure over it. Instead this function is stringified and sent to Phridge, where
+    // it is executed.
+    function executeInsidePhantom(headers, blacklisted, resolve) {
+      var customHeaders = this.customHeaders || {};
+      for (var header in headers) {
+        if (headers.hasOwnProperty(header) && blacklisted.indexOf(header) === -1) {
+          customHeaders[header] = headers[header];
+          // console.debug('Forwarding header ' + header);
+        }
+      }
+      this.customHeaders = customHeaders;
+      resolve();
+    }
+
+    // By setting the headers as an argument here, they will be bound in the function in Phridge.
+    // Transformation is done using JSON.stringify and the resulting JSON object is unpacked in
+    // Phridge. We use a promise based approach so we can detect when phridge has set the headers,
+    // and we continue the middleware chain.
+    req.prerender.page.run(req.headers, BLACKLISTED, executeInsidePhantom
+    ).then(function () {
+      next();
+    }).catch(function () {
+      res.sendStatus(statusCode);
+      res.end('Could not forward sent headers');
+    });
+  }
+};

--- a/server.js
+++ b/server.js
@@ -1,30 +1,32 @@
 var prerender = require('prerender');
 
+var forwardHeaders = require('./forwardHeaders');
+var clearPhantomCache = require('./clearPhantomCache');
+
 var server = prerender({
-	workers: process.env.PRERENDER_NUM_WORKERS || 4
+  workers: process.env.PRERENDER_NUM_WORKERS || 4
 });
 
-
-server.use({
-	//There are some issues with the in-memory cache from PhantomJS 2. It keeps pages in memory,
-	//and then simply returns a 304 instead of a 200 whenever possible.
-	//Prerender unfortunatally simply proxies this status code, even though the client doesn't necessarily
-	//have the page in cache.
-	//In order to prevent this we need to clear the memory cache of PhantomJS before each request
-	onPhantomPageCreate: function(phantom, req, res, next) {
-		//The run function is exposed by phridge (bridge between prerender and PhantomJS), and allows
-		//us to run commands in the page context
-		req.prerender.page.run(function(resolve) {
-			this.clearMemoryCache();
-			resolve();
-		})
-		.then(function() { next() })
-		.catch(function() { next() });
-	}
-});
+server.use(clearPhantomCache);
+server.use(forwardHeaders);
 server.use(prerender.sendPrerenderHeader());
 server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 
 server.start();
 
+function shutdown() {
+  console.log('Shutdown initiated');
+  server.exit();
+  // At this point prerender has started killing its phantom workers already.
+  // We give it 5 seconds to quickly do so, and then halt the process. This
+  // will ensure relatively rapid redeploys (prerender no longer accepts new
+  // requests at this point
+  setTimeout(function () {
+    console.log('Prerender has shut down');
+    process.exit();
+  }, 5000);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
This PR adds the ability for prerender to forward headers to phantomjs

Additionally it ensures prerender shuts down nicely in Docker

@Magnetme/monolith I dont want to talk about it anymore, but please review!