### PR TITLE
Strip comments

### DIFF
--- a/forwardHeaders.js
+++ b/forwardHeaders.js
@@ -32,7 +32,7 @@ module.exports = {
       //see: http://phantomjs.org/api/webpage/property/custom-headers.html
       page.onInitialized = function() {
         page.customHeaders = {};
-      }
+      };
 
       resolve();
     }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "docker-prerender",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Dockerfile to build the prerender container image",
   "main": "server.js",
   "dependencies": {
+    "html-minifier": "^3.0.2",
     "prerender": "4.3.1"
   },
   "devDependencies": {},

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 var prerender = require('prerender');
 
 var forwardHeaders = require('./forwardHeaders');
+var stripHtml = require('./stripHtml');
 
 var server = prerender({
   workers: process.env.PRERENDER_NUM_WORKERS || 4,
@@ -12,6 +13,7 @@ server.use(forwardHeaders);
 server.use(prerender.sendPrerenderHeader());
 server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
+server.use(stripHtml);
 
 server.start();
 

--- a/stripHtml.js
+++ b/stripHtml.js
@@ -1,0 +1,25 @@
+var minify = require('html-minifier').minify;
+
+var options = {
+  minifyCSS: true,
+  minifyJS: true,
+  removeComments: true,
+  collapseWhitespace: true,
+  preserveLineBreaks: true
+};
+
+module.exports = {
+  beforeSend: function(req, res, next) {
+    if(!req.prerender.documentHTML) {
+      return next();
+    }
+
+    var sizeBefore = req.prerender.documentHTML.toString().length;
+    req.prerender.documentHTML = minify(req.prerender.documentHTML.toString(), options);
+    var sizeAfter = req.prerender.documentHTML.toString().length;
+
+    console.log("Size was reduced by " + Math.round((100*(sizeBefore-sizeAfter)*100/sizeBefore))/100 +"%");
+
+    next();
+  }
+};


### PR DESCRIPTION
@TiddoLangerak This strips the following

1. HTML comments
2. HTML whitespace

Regarding whitespace: technically replacing newlines with spaces is not semantically equivalent, but practically I think it does not make much of a difference (plus it made the code so much simpler I think it was worth it)

I used one existing regex, the other ones I've done myself, ad are split into 4 subparts to facilitate easier reading

Size difference:

| Prerender version | Landingpage | Magnet.me about |
|---|---|---|
| 1.3.1 | 26.4kb | 43.3kb |
| 1.4.0 | 26.2kb | 41.1kb |

Render times are not really different