### PR TITLE
Remove empty headers to avoid a webserver reject

### DIFF
--- a/plugins/forwardHeaders.js
+++ b/plugins/forwardHeaders.js
@@ -1,6 +1,7 @@
 // Set all blacklisted headers as lowercase
 const BLACKLISTED = [
 	'user-agent',       // Prerender sets her own user agent, which we dont want to override
+	'host',             // This is set to the host of prerender, so its wrong to forward
 	'accept',           // Let prerender accept everything and handle it
 	'accept-encoding',  // We dont want to forward deflate or gzip since prerender will break on those
 	'connection',       // No sudden keepalive stuff
@@ -20,6 +21,7 @@ module.exports = {
 			newHeader[headerKey] = BLACKLISTED.includes(headerKey) ? '' : header[1];
 			return newHeader;
 		})
+		        .filter(header => header[1] == '')
 			.reduce((a, b) => Object.assign(a, b), {});
 
 		const headersObject = {

--- a/plugins/forwardHeaders.js
+++ b/plugins/forwardHeaders.js
@@ -1,7 +1,6 @@
 // Set all blacklisted headers as lowercase
 const BLACKLISTED = [
 	'user-agent',       // Prerender sets her own user agent, which we dont want to override
-	'host',             // This is set to the host of prerender, so its wrong to forward
 	'accept',           // Let prerender accept everything and handle it
 	'accept-encoding',  // We dont want to forward deflate or gzip since prerender will break on those
 	'connection',       // No sudden keepalive stuff


### PR DESCRIPTION
`forwardHeaders.js` makes `Host` header empty. Some webservers reject such requests (Ex. NGINX with disabled `ignore_invalid_headers` option).

This changes allows the browser to set blacklisted header by its own.